### PR TITLE
add dotenv file to define environment variables and use them in code - fixes #6

### DIFF
--- a/cmd/whatsapptistics/.env
+++ b/cmd/whatsapptistics/.env
@@ -1,0 +1,4 @@
+AWS_S3_CHATS="whatsappchats"
+AWS_DYNAMODB_REPORTS="whatsapptistics_reports"
+TOPIC_ARN="arn:aws:sns:us-east-2:582875565416:whatsapp_chats"
+QUEUE_URL="https://sqs.us-east-2.amazonaws.com/582875565416/whatsapp-chats"

--- a/job/sns/analyze_job_queuer.go
+++ b/job/sns/analyze_job_queuer.go
@@ -4,16 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 
+	_ "github.com/joho/godotenv/autoload"
+
 	"github.com/mdanzinger/whatsapptistics/job"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
-)
-
-const (
-	TopicARN = "arn:aws:sns:us-east-2:582875565416:whatsapp_chats"
 )
 
 type SnsQueuer struct {
@@ -28,7 +26,7 @@ func (s *SnsQueuer) QueueJob(job *job.Chat) error {
 
 	params := &sns.PublishInput{
 		Message:  aws.String(string(j)),
-		TopicArn: aws.String(TopicARN),
+		TopicArn: aws.String(os.Getenv("TOPIC_ARN")),
 	}
 
 	fmt.Println("Params: ", params)

--- a/job/sqs/analyze_job_source.go
+++ b/job/sqs/analyze_job_source.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	_ "github.com/joho/godotenv/autoload"
+
 	"github.com/mdanzinger/whatsapptistics/job"
 	"github.com/mdanzinger/whatsapptistics/job/sns"
 
@@ -14,15 +16,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
-// TODO: Make these env variables
+
 const (
-	QUEUE_URL    = "https://sqs.us-east-2.amazonaws.com/582875565416/whatsapp-chats"
 	MAX_MESSAGES = 10 // sqs has a 10 message limit.
 )
 
 var (
 	params = &sqs.ReceiveMessageInput{
-		QueueUrl:            aws.String(QUEUE_URL), // Required
+		QueueUrl:            aws.String(os.Getenv("QUEUE_URL"), // Required
 		MaxNumberOfMessages: aws.Int64(MAX_MESSAGES),
 		MessageAttributeNames: []*string{
 			aws.String("All"), // Required
@@ -93,7 +94,7 @@ func (s *sqsSource) QueueJob(j *job.Chat) error {
 // deleteMessage removes the message from the queue
 func (s *sqsSource) deleteMessage(handle *string) error {
 	_, err := s.sqs.DeleteMessage(&sqs.DeleteMessageInput{
-		QueueUrl:      aws.String(QUEUE_URL),
+		QueueUrl:      aws.String(os.Getenv("QUEUE_URL"),
 		ReceiptHandle: handle,
 	})
 	if err != nil {

--- a/store/dynamodb/report_repo.go
+++ b/store/dynamodb/report_repo.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	_ "github.com/joho/godotenv/autoload"
+
 	"github.com/mdanzinger/whatsapptistics/report"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -31,7 +33,7 @@ func (s *reportRepo) Get(ctx context.Context, key string) (*report.Report, error
 
 	// Cache misses.. get report from db
 	result, err := s.db.GetItemWithContext(ctx, &dynamodb.GetItemInput{
-		TableName: aws.String("whatsapptistics_reports"),
+		TableName: aws.String(os.Getenv("AWS_DYNAMODB_REPORTS")),
 		Key: map[string]*dynamodb.AttributeValue{
 			"ReportID": {
 				S: aws.String(key),
@@ -70,7 +72,7 @@ func (s *reportRepo) Store(r *report.Report) error {
 
 	input := &dynamodb.PutItemInput{
 		Item:      i,
-		TableName: aws.String("whatsapptistics_reports"),
+		TableName: aws.String(os.Getenv("AWS_DYNAMODB_REPORTS")),
 	}
 
 	// Insert item into db

--- a/store/s3/chat_repo.go
+++ b/store/s3/chat_repo.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 
+	_ "github.com/joho/godotenv/autoload"
+
 	"github.com/mdanzinger/whatsapptistics/chat"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -21,7 +23,7 @@ type chatRepo struct {
 
 func (s *chatRepo) Upload(ctx context.Context, chat *chat.Chat) error {
 	result, err := s.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
-		Bucket: aws.String("whatsappchats"),
+		Bucket: aws.String(os.Getenv("AWS_S3_CHATS")),
 		Key:    aws.String(chat.ChatID),
 		Body:   bytes.NewReader(chat.Content),
 	})
@@ -37,7 +39,7 @@ func (s *chatRepo) Download(id string) (*chat.Chat, error) {
 
 	_, err := s.downloader.Download(reportBuf,
 		&s3.GetObjectInput{
-			Bucket: aws.String("whatsappchats"),
+			Bucket: aws.String(os.Getenv("AWS_S3_CHATS")),
 			Key:    aws.String(id),
 		})
 


### PR DESCRIPTION
Fixes iss #6 by adding a dotenv file which lists the environment variables we can use throughout the code so they are not hard coded.
@mdanzinger what do you think of the way I did it? 

Do you also want
https://github.com/mdanzinger/whatsapptistics/blob/6a893fee3c004e75c9f153edc72d3cded87d587b/notify/report.go#L9-L10
and 
https://github.com/mdanzinger/whatsapptistics/blob/6a893fee3c004e75c9f153edc72d3cded87d587b/notify/ses/report.go#L13-L22
to be used as env variables?